### PR TITLE
Add simple ImGui dark window example

### DIFF
--- a/dark_ui.cpp
+++ b/dark_ui.cpp
@@ -1,0 +1,70 @@
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+#include <GLFW/glfw3.h>
+
+int main() {
+    // Initialize GLFW
+    if (!glfwInit())
+        return -1;
+
+    // Configure GL version (using OpenGL 3.0 for portability)
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+
+    // Create window
+    GLFWwindow* window = glfwCreateWindow(800, 600, "ImGui Dark Window", nullptr, nullptr);
+    if (!window)
+    {
+        glfwTerminate();
+        return -1;
+    }
+    glfwMakeContextCurrent(window);
+    glfwSwapInterval(1); // Enable vsync
+
+    // Setup Dear ImGui context
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO& io = ImGui::GetIO(); (void)io;
+
+    // Use dark style
+    ImGui::StyleColorsDark();
+
+    // Initialize platform/renderer bindings
+    ImGui_ImplGlfw_InitForOpenGL(window, true);
+    ImGui_ImplOpenGL3_Init("#version 130");
+
+    // Main loop
+    while (!glfwWindowShouldClose(window))
+    {
+        glfwPollEvents();
+
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
+
+        // Blank window just to show the dark theme
+        ImGui::Begin(" ");
+        ImGui::End();
+
+        // Rendering
+        ImGui::Render();
+        int display_w, display_h;
+        glfwGetFramebufferSize(window, &display_w, &display_h);
+        glViewport(0, 0, display_w, display_h);
+        glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+        glfwSwapBuffers(window);
+    }
+
+    // Cleanup
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+
+    glfwDestroyWindow(window);
+    glfwTerminate();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `dark_ui.cpp` showing a minimal Dear ImGui setup for a dark themed blank window

## Testing
- `apt-get update`
- `apt-get install -y bsdmainutils`


------
https://chatgpt.com/codex/tasks/task_e_6851c9a351ac8333b6644e55bcfb3a62